### PR TITLE
Added forestry to storage options and it's relating items.

### DIFF
--- a/src/main/java/com/wastedbankspace/WastedBankSpaceConfig.java
+++ b/src/main/java/com/wastedbankspace/WastedBankSpaceConfig.java
@@ -51,6 +51,8 @@ public interface WastedBankSpaceConfig extends Config
 
 	String SPICE_RACK_CHECK_KEY = "spiceRackCheck";
 
+	String FORESTRY_KIT_CHECK_KEY = "forestryKitCheck";
+
 	@ConfigItem(keyName = CLUE_ITEM_CHECK_KEY,
 			name = "PoH Clue Item Storage",
 			description = "Treasure Chest Storage",
@@ -177,16 +179,25 @@ public interface WastedBankSpaceConfig extends Config
 			position = 13
 	)
 	default	boolean toyBoxCheck()
-  {
+	{
 		return true;
 	}
-  
-  @ConfigItem(keyName = SPICE_RACK_CHECK_KEY,
-		name = "Spice rack storage",
-		description = "Storage for spicy stew spices in the PoH kitchen",
-		position = 13)
-	default boolean spiceRackStorageCheck() 
-  { 
-    return true; 
-  }
+
+	@ConfigItem(keyName = SPICE_RACK_CHECK_KEY,
+			name = "Spice rack storage",
+			description = "Storage for spicy stew spices in the PoH kitchen",
+			position = 13)
+	default boolean spiceRackStorageCheck()
+	{
+		return true;
+	}
+
+	@ConfigItem(keyName = FORESTRY_KIT_CHECK_KEY,
+			name = "Forestry kit storage",
+			description = "Storage for Forestry-related items",
+			position = 14)
+	default boolean forestryKitCheck()
+	{
+		return true;
+	}
 }

--- a/src/main/java/com/wastedbankspace/WastedBankSpacePlugin.java
+++ b/src/main/java/com/wastedbankspace/WastedBankSpacePlugin.java
@@ -112,7 +112,8 @@ public class WastedBankSpacePlugin extends Plugin
 			new StorageLocationEnabler(StorageLocation.FANCY_DRESS_BOX, () -> config.fancyDressBoxStorageCheck(), StorableItem.fancyDressBoxItems),
 			new StorageLocationEnabler(StorageLocation.MAGIC_WARDROBE, () -> config.magicWardrobeStorageCheck(), StorableItem.magicWardrobeItems),
 			new StorageLocationEnabler(StorageLocation.TOY_BOX, () -> config.toyBoxCheck(), StorableItem.toyBoxItems),
-			new StorageLocationEnabler(StorageLocation.SPICE_RACK, () -> config.spiceRackStorageCheck(), StorableItem.spiceRackItems)
+			new StorageLocationEnabler(StorageLocation.SPICE_RACK, () -> config.spiceRackStorageCheck(), StorableItem.spiceRackItems),
+			new StorageLocationEnabler(StorageLocation.FORESTRY_KIT, () -> config.forestryKitCheck(), StorableItem.forestryKitItems)
 	);
 
 	private NavigationButton navButton;

--- a/src/main/java/com/wastedbankspace/model/StorableItem.java
+++ b/src/main/java/com/wastedbankspace/model/StorableItem.java
@@ -1335,6 +1335,34 @@ public enum StorableItem {
     BROWN_SPICE_2(ItemID.BROWN_SPICE_2, StorageLocation.SPICE_RACK),
     BROWN_SPICE_3(ItemID.BROWN_SPICE_3, StorageLocation.SPICE_RACK),
     BROWN_SPICE_4(ItemID.BROWN_SPICE_4, StorageLocation.SPICE_RACK),
+    /**
+     * Forestry Kit
+     */
+    ANIMAINFUSED_BARK(ItemID.ANIMAINFUSED_BARK, StorageLocation.FORESTRY_KIT),
+    FORESTERS_RATION(ItemID.FORESTERS_RATION, StorageLocation.FORESTRY_KIT),
+    SECATEURS_ATTACHMENT(ItemID.SECATEURS_ATTACHMENT, StorageLocation.FORESTRY_KIT),
+    NATURE_OFFERINGS(ItemID.NATURE_OFFERINGS, StorageLocation.FORESTRY_KIT),
+    WOODCUTTING_CAPE(ItemID.WOODCUTTING_CAPE, StorageLocation.FORESTRY_KIT),
+    LUMBERJACK_TOP(ItemID.LUMBERJACK_TOP, StorageLocation.FORESTRY_KIT),
+    LUMBERJACK_HAT(ItemID.LUMBERJACK_HAT, StorageLocation.FORESTRY_KIT),
+    LUMBERJACK_BOOTS(ItemID.LUMBERJACK_BOOTS, StorageLocation.FORESTRY_KIT),
+    LUMBERJACK_LEGS(ItemID.LUMBERJACK_LEGS, StorageLocation.FORESTRY_KIT),
+    FORESTRY_TOP(ItemID.FORESTRY_TOP, StorageLocation.FORESTRY_KIT),
+    FORESTRY_HAT(ItemID.FORESTRY_HAT, StorageLocation.FORESTRY_KIT),
+    FORESTRY_BOOTS(ItemID.FORESTRY_BOOTS, StorageLocation.FORESTRY_KIT),
+    FORESTRY_LEGS(ItemID.FORESTRY_LEGS, StorageLocation.FORESTRY_KIT),
+    BEE_ON_A_STICK(ItemID.BEE_ON_A_STICK, StorageLocation.FORESTRY_KIT),
+    LEPRECHAUN_CHARM(ItemID.LEPRECHAUN_CHARM, StorageLocation.FORESTRY_KIT),
+    PADDED_SPOON(ItemID.PADDED_SPOON, StorageLocation.FORESTRY_KIT),
+    PETAL_CIRCLET(ItemID.PETAL_CIRCLET, StorageLocation.FORESTRY_KIT),
+    SMOKER_CANISTER(ItemID.SMOKER_CANISTER, StorageLocation.FORESTRY_KIT),
+    TRAP_DISARMER(ItemID.TRAP_DISARMER, StorageLocation.FORESTRY_KIT),
+    MAGIC_LEAVES(ItemID.MAGIC_LEAVES, StorageLocation.FORESTRY_KIT),
+    YEW_LEAVES(ItemID.YEW_LEAVES, StorageLocation.FORESTRY_KIT),
+    MAPLE_LEAVES(ItemID.MAPLE_LEAVES, StorageLocation.FORESTRY_KIT),
+    WILLOW_LEAVES(ItemID.WILLOW_LEAVES, StorageLocation.FORESTRY_KIT),
+    OAK_LEAVES(ItemID.OAK_LEAVES, StorageLocation.FORESTRY_KIT),
+    LEAVES(ItemID.LEAVES, StorageLocation.FORESTRY_KIT),
     ;
 
     public final int itemID;
@@ -1357,6 +1385,7 @@ public enum StorableItem {
     public static final List<StorableItem> toyBoxItems = storableItemsAtLocation(StorageLocation.TOY_BOX);
 
     public static final List<StorableItem> spiceRackItems = storableItemsAtLocation(StorageLocation.SPICE_RACK);
+    public static final List<StorableItem> forestryKitItems = storableItemsAtLocation(StorageLocation.FORESTRY_KIT);
 
     private static final Map<StorableItem, String> storableItemNameMap = new HashMap<>();
     private static final Map<Integer, StorableItem> ITEM_ID_MAP = new HashMap<>();

--- a/src/main/java/com/wastedbankspace/model/StorageLocation.java
+++ b/src/main/java/com/wastedbankspace/model/StorageLocation.java
@@ -48,7 +48,8 @@ public enum StorageLocation {
     FANCY_DRESS_BOX("PoH Fancy Dress Box"),
     MAGIC_WARDROBE("PoH Magic Wardrobe"),
     TOY_BOX("PoH Toy Box"),
-    SPICE_RACK("PoH Spice rack")
+    SPICE_RACK("PoH Spice rack"),
+    FORESTRY_KIT("Forestry kit")
     ;
 
     private final String uiRepresentation;


### PR DESCRIPTION
Added forestry kit +
Anima-infused bark - the reward currency obtained by completing Forestry events, which can be used alongside various logs to purchase rewards from the Forestry Shop.
Forester's ration - enables the passive effect of felling axes
Secateurs attachment - roughly doubles the amount of leaves players receive from chopping trees.
Nature offerings - gives a 60–80% chance to receive an additional log.
Tree leaves - if the kit is equipped or in the inventory, leaves gathered from woodcutting will automatically be stored here.
Lumberjack/Forestry outfit - if the clothes pouch is used on the kit, the outfits can be stored inside to receive its benefit without needing to wear it.
Woodcutting cape - if the cape pouch is used on the kit, the skillcape can be stored inside to receive its benefit without needing to wear it.
Event-enabling items - allows specific forestry events to occur, consuming the item:
    Bee on a stick - Flowering Bush
    Leprechaun charm - Woodcutting Leprechaun
    Padded spoon - Pheasant Control
    Petal circlet - Enchantment Ritual
    Smoker canister - Bee Hive