### PR TITLE
Add badges for plugin rank and total installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Wasted Bank Space
+
+![image](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/wasted-bank-space)
+![image](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/wasted-bank-space)
+
 Plugin to show what items in your bank can be stored elsewhere in Gielinor, to save you bank space.
 
 # How it works


### PR DESCRIPTION
Adds clean little badges to the README. Borrowed from Guardians of the Rift plugin when I noticed Wasted Bank Space is rank 39 on the plugin hub by number of installs (badge says 41 for some reason).