### PR TITLE
Add missing 'update panel from ignore list' call

### DIFF
--- a/src/main/java/com/wastedbankspace/WastedBankSpacePlugin.java
+++ b/src/main/java/com/wastedbankspace/WastedBankSpacePlugin.java
@@ -383,6 +383,7 @@ public class WastedBankSpacePlugin extends Plugin
 				log.debug("onConfigChanged(): Attempted update of enabledItems hashset failed.\nEvent: {}\n", event);
 			}
 			updateWastedBankSpace();
+			processIgnoreListChanged(panel.getFilterdItemsText());
 		} else if(eventKey.equals(WastedBankSpaceConfig.FILTER_ENABLED_CHECK_KEY) || eventKey.equals(WastedBankSpaceConfig.BIS_FILTER_ENABLED_CHECK_KEY)){
 			//Moderate jank to reforce filter and BIS check. TODO These should be separated into two functions
 			processIgnoreListChanged(panel.getFilterdItemsText());


### PR DESCRIPTION
When event key matched a storage location key, we would update the calculated wasted bank space, but we never called for an update to then process the ignore list to filter out results. This change adds processIgnoreListChanged() after updateWastedBankSpace() within the onConfigChanged() event subscriber.

This should address #119 